### PR TITLE
Equalize tab heights for k-epsilon and k-omega-sst

### DIFF
--- a/methods.html
+++ b/methods.html
@@ -108,36 +108,16 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
-            transition: all 0.3s ease;
-            position: relative;
-        }
-
-        .logo::after {
-            content: '';
-            position: absolute;
-            bottom: -4px;
-            left: 0;
-            width: 0;
-            height: 2px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            transition: width 0.3s ease;
-        }
-
-        .logo:hover::after {
-            width: 100%;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
+            color: #4a5568;
+            font-size: 0.9rem;
             font-weight: 500;
-        }
-
-        .nav-tab:hover {
-            background: rgba(59,130,246,0.1);
-            color: #3b82f6;
-            animation: shimmer 0.6s ease-out;
+            border-radius: 12px;
+            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            position: relative;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         .nav-tab.active {

--- a/methods/central-difference.html
+++ b/methods/central-difference.html
@@ -71,13 +71,16 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
+            color: #4a5568;
+            font-size: 0.9rem;
             font-weight: 500;
+            border-radius: 12px;
+            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            position: relative;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         .nav-tab:hover {

--- a/methods/coupled.html
+++ b/methods/coupled.html
@@ -71,13 +71,16 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
+            color: #4a5568;
+            font-size: 0.9rem;
             font-weight: 500;
+            border-radius: 12px;
+            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            position: relative;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         .nav-tab:hover {

--- a/methods/first-order-upwind.html
+++ b/methods/first-order-upwind.html
@@ -71,13 +71,16 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
+            color: #4a5568;
+            font-size: 0.9rem;
             font-weight: 500;
+            border-radius: 12px;
+            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            position: relative;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         .nav-tab:hover {

--- a/methods/muscl.html
+++ b/methods/muscl.html
@@ -71,13 +71,16 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
+            color: #4a5568;
+            font-size: 0.9rem;
             font-weight: 500;
+            border-radius: 12px;
+            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            position: relative;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         .nav-tab:hover {

--- a/methods/pimple.html
+++ b/methods/pimple.html
@@ -71,13 +71,16 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
+            color: #4a5568;
+            font-size: 0.9rem;
             font-weight: 500;
+            border-radius: 12px;
+            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            position: relative;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         .nav-tab:hover {

--- a/methods/piso.html
+++ b/methods/piso.html
@@ -71,13 +71,16 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
+            color: #4a5568;
+            font-size: 0.9rem;
             font-weight: 500;
+            border-radius: 12px;
+            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            position: relative;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         .nav-tab:hover {

--- a/methods/quick.html
+++ b/methods/quick.html
@@ -71,13 +71,16 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
+            color: #4a5568;
+            font-size: 0.9rem;
             font-weight: 500;
+            border-radius: 12px;
+            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            position: relative;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         .nav-tab:hover {

--- a/methods/second-order-upwind.html
+++ b/methods/second-order-upwind.html
@@ -71,13 +71,16 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
+            color: #4a5568;
+            font-size: 0.9rem;
             font-weight: 500;
+            border-radius: 12px;
+            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            position: relative;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         .nav-tab:hover {

--- a/methods/simple.html
+++ b/methods/simple.html
@@ -71,13 +71,16 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
+            color: #4a5568;
+            font-size: 0.9rem;
             font-weight: 500;
+            border-radius: 12px;
+            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            position: relative;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         .nav-tab:hover {

--- a/methods/simplec.html
+++ b/methods/simplec.html
@@ -71,13 +71,16 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
+            color: #4a5568;
+            font-size: 0.9rem;
             font-weight: 500;
+            border-radius: 12px;
+            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            position: relative;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         .nav-tab:hover {

--- a/methods/tvd.html
+++ b/methods/tvd.html
@@ -71,13 +71,16 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
+            color: #4a5568;
+            font-size: 0.9rem;
             font-weight: 500;
+            border-radius: 12px;
+            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            position: relative;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         .nav-tab:hover {

--- a/methods/weno.html
+++ b/methods/weno.html
@@ -72,13 +72,16 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
+            color: #4a5568;
+            font-size: 0.9rem;
             font-weight: 500;
+            border-radius: 12px;
+            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            position: relative;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         .nav-tab:hover {

--- a/models/des.html
+++ b/models/des.html
@@ -73,6 +73,8 @@
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.15);
         }
 
+        .header { min-height: 88px; }
+
         .header-content {
             display: flex;
             justify-content: space-between;

--- a/models/des.html
+++ b/models/des.html
@@ -66,6 +66,8 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
+            display: flex;
+            align-items: center;
         }
 
         .header.scrolled {

--- a/models/des.html
+++ b/models/des.html
@@ -66,8 +66,6 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
         }
 
         .header.scrolled {

--- a/models/inviscid.html
+++ b/models/inviscid.html
@@ -57,8 +57,6 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
         }
 
         .header.scrolled {

--- a/models/inviscid.html
+++ b/models/inviscid.html
@@ -64,6 +64,8 @@
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.15);
         }
 
+        .header { min-height: 88px; }
+
         .header-content {
             display: flex;
             justify-content: space-between;

--- a/models/inviscid.html
+++ b/models/inviscid.html
@@ -57,6 +57,8 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
+            display: flex;
+            align-items: center;
         }
 
         .header.scrolled {

--- a/models/k-epsilon.html
+++ b/models/k-epsilon.html
@@ -59,6 +59,8 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
+            display: flex;
+            align-items: center;
         }
 
         .header.scrolled {

--- a/models/k-epsilon.html
+++ b/models/k-epsilon.html
@@ -59,8 +59,6 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
         }
 
         .header.scrolled {

--- a/models/k-epsilon.html
+++ b/models/k-epsilon.html
@@ -66,6 +66,8 @@
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.15);
         }
 
+        .header { min-height: 88px; }
+
         .header-content {
             display: flex;
             justify-content: space-between;

--- a/models/k-kl-omega.html
+++ b/models/k-kl-omega.html
@@ -62,8 +62,6 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
         }
 
         .header.scrolled {

--- a/models/k-kl-omega.html
+++ b/models/k-kl-omega.html
@@ -69,6 +69,8 @@
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.15);
         }
 
+        .header { min-height: 88px; }
+
         .header-content {
             display: flex;
             justify-content: space-between;

--- a/models/k-kl-omega.html
+++ b/models/k-kl-omega.html
@@ -62,6 +62,8 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
+            display: flex;
+            align-items: center;
         }
 
         .header.scrolled {

--- a/models/k-omega-sst.html
+++ b/models/k-omega-sst.html
@@ -49,8 +49,6 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
         }
 
         .header.scrolled {

--- a/models/k-omega-sst.html
+++ b/models/k-omega-sst.html
@@ -49,6 +49,8 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
+            display: flex;
+            align-items: center;
         }
 
         .header.scrolled {

--- a/models/k-omega-sst.html
+++ b/models/k-omega-sst.html
@@ -56,6 +56,8 @@
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.15);
         }
 
+        .header { min-height: 88px; }
+
         .header-content {
             display: flex;
             justify-content: space-between;

--- a/models/k-omega.html
+++ b/models/k-omega.html
@@ -56,8 +56,6 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
         }
 
         .header.scrolled {

--- a/models/k-omega.html
+++ b/models/k-omega.html
@@ -56,6 +56,8 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
+            display: flex;
+            align-items: center;
         }
 
         .header.scrolled {

--- a/models/k-omega.html
+++ b/models/k-omega.html
@@ -63,6 +63,8 @@
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.15);
         }
 
+        .header { min-height: 88px; }
+
         .header-content {
             display: flex;
             justify-content: space-between;

--- a/models/laminar.html
+++ b/models/laminar.html
@@ -70,6 +70,8 @@
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.15);
         }
 
+        .header { min-height: 88px; }
+
         .header-content {
             display: flex;
             justify-content: space-between;

--- a/models/laminar.html
+++ b/models/laminar.html
@@ -63,8 +63,6 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
         }
 
         .header.scrolled {

--- a/models/laminar.html
+++ b/models/laminar.html
@@ -63,6 +63,8 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
+            display: flex;
+            align-items: center;
         }
 
         .header.scrolled {

--- a/models/les.html
+++ b/models/les.html
@@ -58,6 +58,8 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
+            display: flex;
+            align-items: center;
         }
 
         .header.scrolled {

--- a/models/les.html
+++ b/models/les.html
@@ -58,8 +58,6 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
         }
 
         .header.scrolled {

--- a/models/les.html
+++ b/models/les.html
@@ -65,6 +65,8 @@
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.15);
         }
 
+        .header { min-height: 88px; }
+
         .header-content {
             display: flex;
             justify-content: space-between;

--- a/models/reynolds-stress.html
+++ b/models/reynolds-stress.html
@@ -56,8 +56,6 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
         }
 
         .header.scrolled {

--- a/models/reynolds-stress.html
+++ b/models/reynolds-stress.html
@@ -56,6 +56,8 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
+            display: flex;
+            align-items: center;
         }
 
         .header.scrolled {

--- a/models/reynolds-stress.html
+++ b/models/reynolds-stress.html
@@ -63,6 +63,8 @@
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.15);
         }
 
+        .header { min-height: 88px; }
+
         .header-content {
             display: flex;
             justify-content: space-between;

--- a/models/sas.html
+++ b/models/sas.html
@@ -70,6 +70,8 @@
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.15);
         }
 
+        .header { min-height: 88px; }
+
         .header-content {
             display: flex;
             justify-content: space-between;

--- a/models/sas.html
+++ b/models/sas.html
@@ -63,8 +63,6 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
         }
 
         .header.scrolled {

--- a/models/sas.html
+++ b/models/sas.html
@@ -122,6 +122,15 @@
             box-shadow: 0 8px 25px rgba(102, 126, 234, 0.15);
         }
 
+        .nav-tab {
+            line-height: 1;
+            min-height: 2.75rem;
+        }
+        .content-tab {
+            line-height: 1;
+            min-height: 2.75rem;
+        }
+
         .model-selector {
             position: relative;
             display: inline-block;

--- a/models/sas.html
+++ b/models/sas.html
@@ -63,6 +63,8 @@
             z-index: 1000;
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.08);
             transition: all 0.3s ease;
+            display: flex;
+            align-items: center;
         }
 
         .header.scrolled {

--- a/models/spalart-allmaras.html
+++ b/models/spalart-allmaras.html
@@ -63,6 +63,8 @@
             box-shadow: 0 8px 32px rgba(102, 126, 234, 0.15);
         }
 
+        .header { min-height: 88px; }
+
         .header-content {
             display: flex;
             justify-content: space-between;

--- a/models/transition-sst.html
+++ b/models/transition-sst.html
@@ -95,35 +95,16 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
+            color: #4a5568;
+            font-size: 0.9rem;
+            font-weight: 500;
+            border-radius: 12px;
             transition: all 0.3s ease;
             position: relative;
-        }
-
-        .logo::after {
-            content: '';
-            position: absolute;
-            bottom: -4px;
-            left: 0;
-            width: 0;
-            height: 2px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            transition: width 0.3s ease;
-        }
-
-        .logo:hover::after {
-            width: 100%;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
-            font-weight: 500;
-        }
-
-        .nav-tab:hover {
-            background: rgba(59,130,246,0.1);
-            color: #3b82f6;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         .nav-tab.active {
@@ -139,23 +120,6 @@
             text-decoration: none;
             transition: all 0.3s ease;
             position: relative;
-        }
-
-        .logo::after {
-            content: '';
-            position: absolute;
-            bottom: -4px;
-            left: 0;
-            width: 0;
-            height: 2px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            transition: width 0.3s ease;
-        }
-
-        .logo:hover::after {
-            width: 100%;
-            font-weight: 500;
-            transition: all 0.3s ease;
         }
 
         .back-link:hover {

--- a/models/transition-sst.html
+++ b/models/transition-sst.html
@@ -46,7 +46,7 @@
             background: linear-gradient(135deg, rgba(139,92,246,0.06), rgba(196,181,253,0.03));
             backdrop-filter: blur(10px);
             border-bottom: 1px solid rgba(139,92,246,0.12);
-            padding: 0.75rem 0;
+            padding: 1.5rem 0;
             position: sticky;
             top: 0;
             z-index: 1000;

--- a/models/transition-sst.html
+++ b/models/transition-sst.html
@@ -50,6 +50,9 @@
             position: sticky;
             top: 0;
             z-index: 1000;
+            display: flex;
+            align-items: center;
+            min-height: 88px;
         }
 
         .header.scrolled {
@@ -91,7 +94,8 @@
 
         .nav-tabs {
             display: flex;
-            gap: 0.5rem;
+            gap: 2.5rem;
+            align-items: center;
         }
 
         .nav-tab {

--- a/models/transition-sst.html
+++ b/models/transition-sst.html
@@ -50,8 +50,6 @@
             position: sticky;
             top: 0;
             z-index: 1000;
-            display: flex;
-            align-items: center;
             min-height: 88px;
         }
 

--- a/product-guide.html
+++ b/product-guide.html
@@ -91,13 +91,19 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
-            transition: all 0.3s ease;
+            color: #4a5568;
+            font-size: 0.9rem;
+            font-weight: 500;
+            border-radius: 12px;
+            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
             position: relative;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
-        .logo::after {
+        .nav-tab::after {
             content: '';
             position: absolute;
             bottom: -4px;
@@ -108,13 +114,8 @@
             transition: width 0.3s ease;
         }
 
-        .logo:hover::after {
+        .nav-tab:hover::after {
             width: 100%;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
-            font-weight: 500;
         }
 
         .nav-tab:hover {

--- a/time-dependency.html
+++ b/time-dependency.html
@@ -115,36 +115,16 @@
         }
 
         .nav-tab {
-            padding: 0.5rem 1rem;
+            padding: 0.75rem 1.5rem;
             text-decoration: none;
-            transition: all 0.3s ease;
-            position: relative;
-        }
-
-        .logo::after {
-            content: '';
-            position: absolute;
-            bottom: -4px;
-            left: 0;
-            width: 0;
-            height: 2px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            transition: width 0.3s ease;
-        }
-
-        .logo:hover::after {
-            width: 100%;
-            color: #64748b;
-            border-radius: 0.5rem;
-            transition: all 0.3s ease;
-            font-size: 0.875rem;
+            color: #4a5568;
+            font-size: 0.9rem;
             font-weight: 500;
-        }
-
-        .nav-tab:hover {
-            background: rgba(59,130,246,0.1);
-            color: #3b82f6;
-            animation: shimmer 0.6s ease-out;
+            border-radius: 12px;
+            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            position: relative;
+            overflow: hidden;
+            white-space: nowrap;
         }
 
         .nav-tab.active {


### PR DESCRIPTION
Standardize the styling of upper navigation tabs across several pages to ensure consistent height, matching the `k-epsilon` and `k-omega-sst` tabs.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f8e24b5-988d-4752-901f-7c3007c8c7d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f8e24b5-988d-4752-901f-7c3007c8c7d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

