### PR TITLE
Add robots.txt and sitemap.xml for search engines

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://cfdhandbook.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://cfdhandbook.com/</loc>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://cfdhandbook.com/about.html</loc>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://cfdhandbook.com/contact.html</loc>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Add `robots.txt` and `sitemap.xml` to improve Google search engine optimization.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1d7992f-6287-4f91-ba8a-328d96323162">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f1d7992f-6287-4f91-ba8a-328d96323162">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

